### PR TITLE
Show pointer during node selection

### DIFF
--- a/web/static/css/app.scss
+++ b/web/static/css/app.scss
@@ -171,6 +171,7 @@ g.node {
     margin: 0;
 
     li {
+      cursor: pointer;
       font: 12px sans-serif;
     }
 


### PR DESCRIPTION
Hi,

first of all: thanks for you for working on visualixir. It's really nice :-)

While trying for the first time I was confused when selecting nodes because I did not know how to do it.
Once I have realized I have to click on a node name I thought the mouse cursor could actually be a "pointer".

This commit enables that.

What do you think?

Kind regards,
  Peter