### PR TITLE
:mouse::bug: Tweaked pattern match of `:supervisor` in tracer.ex

### DIFF
--- a/lib/visualixir/tracer.ex
+++ b/lib/visualixir/tracer.ex
@@ -153,9 +153,15 @@ defmodule Visualixir.Tracer do
   end
 
   defp process_type(pid) when is_pid(pid) do
+    # pid
+    # |> :erlang.process_info(:dictionary)
+    # |> inspect
+    # |> IO.puts
     case :erlang.process_info(pid, :dictionary) do
       :undefined -> :dead
-      {_, [{_, _}, "$initial_call": {:supervisor, _, _}]} -> :supervisor
+      # Example:
+      # {:dictionary, ["$initial_call": {:supervisor, :httpc_profile_sup, 1}, "$ancestors": [:httpc_sup, :inets_sup, #PID<0.128.0>]]}
+      {_, ["$initial_call": {:supervisor, _, _}, "$ancestors": _]} -> :supervisor
       _ -> :normal
     end
   end


### PR DESCRIPTION
* On my machine, supervisors weren't showing up dark blue.
  In examining the shape of the supervisor pattern match in
  `Visualixir.Tracer.process_type/1` (pid), the order of the list
  was backwards, with `"$initial_call"` at position 0 and
  `"$ancestors"` at position 1. So I just switched these two. Now
  my supervisors are showing dark blue.
  * Erlang 19, Elixir 1.4.0 (but earlier versions of Elixir also
    exhibited the behavior).
  * I've left in the IO.puts call for your convenience in the code.
    You may want to remove this before committing the changes.