### PR TITLE
Changed alias from Visualixir.TraceChannel to VisualixirWeb.TraceChannel

### DIFF
--- a/lib/visualixir/tracer.ex
+++ b/lib/visualixir/tracer.ex
@@ -1,6 +1,6 @@
 defmodule Visualixir.Tracer do
   use GenServer
-  alias Visualixir.TraceChannel
+  alias VisualixirWeb.TraceChannel
   require Logger
 
   def start(node) do


### PR DESCRIPTION
Fixed alias in Visualixir.Tracer to point to VisualixirWeb.TraceChannel after name change.